### PR TITLE
Use no-padded numbers for day link titles

### DIFF
--- a/lib/run.rb
+++ b/lib/run.rb
@@ -45,7 +45,7 @@ Dir.glob(File.join(config["directory"], "*.xls")).each do |file|
     next if report[:date].is_a? String
     next if report[:date].nil? 
     browser.link(text: "New record").click
-    browser.link(title: report[:date].strftime("%B %d")).click
+    browser.link(title: report[:date].strftime("%B %-d")).click
     browser.select_list(id: "ctl00_ContentPlaceHolder_idProyectoDropDownList").select("iSeatz - iSeatz")
     browser.select_list(id: "ctl00_ContentPlaceHolder_idTipoAsignacionDropDownList").select("Software Development")
     browser.text_field(id: "ctl00_ContentPlaceHolder_TiempoTextBox").set report[:hours]


### PR DESCRIPTION
Generated links titles for the day were using padding (e.j. "March 04" instead of "March 4") which were generating this error:
`unable to locate element, using {:title=>"March 04", :tag_name=>"a"}`
